### PR TITLE
Prevent mutating the client base URL

### DIFF
--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	p "path"
 	"runtime"
 	"strings"
 	"time"

--- a/internal/pkg/client/client_test.go
+++ b/internal/pkg/client/client_test.go
@@ -45,7 +45,7 @@ func TestNew(t *testing.T) {
 
 func TestGenerateAuthToken(t *testing.T) {
 	c := setup()
-	token := c.generateAuthToken()
+	token := c.generateAuthToken(c.BaseURL, c.method)
 	assert.NotNil(t, token)
 
 	// assert for string format matching `MAC id="%s", ts="%d", nonce="%d", mac="%s"`
@@ -64,7 +64,7 @@ func TestNewRequest(t *testing.T) {
 	req, err := c.NewRequest(http.MethodGet, "/sms", nil)
 
 	assert.NoError(t, err)
-	assert.Equal(t, http.MethodGet, c.method)
+	assert.Equal(t, http.MethodGet, req.Method)
 	assert.Equal(t, constants.ContentType, req.Header.Get("Accept"))
 	assert.Equal(t, constants.ContentType, req.Header.Get("Content-Type"))
 	assert.Equal(t, "utf-8", req.Header.Get("Accept-Charset"))
@@ -85,8 +85,8 @@ func TestDo(t *testing.T) {
 	req, err := c.NewRequest(http.MethodPost, "/sms", p)
 
 	assert.NoError(t, err)
-	assert.Equal(t, c.method, http.MethodPost)
 	assert.NotNil(t, req)
+	assert.Equal(t, http.MethodPost, req.Method)
 
 	sms := &api.SmsResponse{}
 	err = c.Do(req, sms)
@@ -108,8 +108,8 @@ func TestDoWithGarbageResponse(t *testing.T) {
 	req, err := c.NewRequest(http.MethodPost, "/sms", p)
 
 	assert.NoError(t, err)
-	assert.Equal(t, c.method, http.MethodPost)
 	assert.NotNil(t, req)
+	assert.Equal(t, http.MethodPost, req.Method)
 
 	balance := &api.BalanceResponse{}
 
@@ -146,8 +146,8 @@ func TestDoNoContentResponse(t *testing.T) {
 	req, err := c.NewRequest(http.MethodDelete, "/sms/6746514019161950", nil)
 
 	assert.NoError(t, err)
-	assert.Equal(t, c.method, http.MethodDelete)
 	assert.NotNil(t, req)
+	assert.Equal(t, http.MethodDelete, req.Method)
 
 	err = c.Do(req, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
In instances where a single use of the client is maintained throughout the lifetime of an application, there are operations that mutate the state of the client making it unusable for future requests.

For example, when sending three SMS messages a minute apart from each other, the log output shows the following:
```
{"level":"debug","REST CLIENT":"Do","time":"2024-06-20T18:37:00+10:00","message":"Sending POST request to https://api.smsglobal.com/v2/sms"}
...
{"level":"debug","REST CLIENT":"Do","time":"2024-06-20T18:38:00+10:00","message":"Sending POST request to https://api.smsglobal.com/v2/sms/sms"}
...
{"level":"debug","REST CLIENT":"Do","time":"2024-06-20T18:39:00+10:00","message":"Sending POST request to https://api.smsglobal.com/v2/sms/sms/sms"}
```

The issue is that when appending the path to the baseURL, it mutates the baseURL.

https://github.com/smsglobal/smsglobal-go/blob/462942118f6bcde841ea3907df9079da146b001e/internal/pkg/client/client.go#L68-L69

This PR changes the way URL's are generated so that they are no longer mutating the client's BaseURL object.
Instead, it now creates it's own object used to create a request.